### PR TITLE
Allow passing auth file to authenticate with OpenVPN server

### DIFF
--- a/data/scripts/entry.sh
+++ b/data/scripts/entry.sh
@@ -181,9 +181,20 @@ if [ "$SOCKS_PROXY" = "on" ]; then
     /data/scripts/dante_wrapper.sh &
 fi
 
+ovpn_auth_flag=''
+if [ -n "$OPENVPN_AUTH_SECRET" ]; then 
+    if [ -f "/run/secrets/$OPENVPN_AUTH_SECRET" ]; then
+        echo "Configuring OpenVPN authentication."
+        ovpn_auth_flag="--auth-user-pass /run/secrets/$OPENVPN_AUTH_SECRET"
+    else
+        echo "WARNING: OpenVPN Credentials secrets fail to read."
+    fi
+fi
+
 echo -e "Running OpenVPN client.\n"
 
 openvpn --config "$config_file_modified" \
+    $ovpn_auth_flag \
     --verb "$vpn_log_level" \
     --auth-nocache \
     --connect-retry-max 10 \


### PR DESCRIPTION
# Summary

This will allow usage with private VPN that required authentication by setting `OPENVPN_AUTH_SECRET` environment variable. It's value should match the **name** of the secret (NOT the file used by the secret) 

The secret should point to a text file with `username` & `password` in separate line, as in the [official docs](https://openvpn.net/community-resources/reference-manual-for-openvpn-2-0/):

>  __--auth-user-pass [up]__
>
> Authenticate with server using username/password. upis a file containing username/password on 2 lines (Note: OpenVPN will only read passwords from a file if it has been built with the --enable-password-save configure option, or on Windows by defining ENABLE_PASSWORD_SAVE in config-win32.h).If up is omitted, username/password will be prompted from the console. 

# Example Usage
```yml
services:
  vpn:
    image: ghcr.io/wfg/openvpn-client
    cap_add: [NET_ADMIN]
    devices: [/dev/net/tun]
    environment:
      - HTTP_PROXY=on
      - SOCKS_PROXY=on
      - OPENVPN_AUTH_SECRET=ovpn_auth
    volumes: [~/local/vpn:/data/vpn]
    ports: ["1080:1080", "8080:8080"]
    secrets: [ovpn_auth]

secrets:
  ovpn_auth: { file: ./secrets/auth.txt }
```

# TODO

- Allow passing `OPENVPN_USERNAME` & `OPENVPN_PASSWORD` instead (maybe?)
- Update docs