### PR TITLE
Basic mapping so that iptables can still create valid tcp rules

### DIFF
--- a/data/scripts/entry.sh
+++ b/data/scripts/entry.sh
@@ -120,6 +120,11 @@ if [[ "$KILL_SWITCH" == "on" ]]; then
             # Use protocol from 'remote' line, then 'proto' line, then 'udp'.
             protocol=${remote[2]:-${global_protocol:-udp}}
 
+            # Map from OpenVPN tcp-client config option to tcp for iptables
+            if [[ $protocol == "tcp-client" ]]; then
+                protocol='tcp'
+            fi
+
             ip_regex='^(([1-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))\.){3}([1-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))$'
             if [[ "$address" =~ $ip_regex ]]; then
                 echo "    IP: $address PORT: $port PROTOCOL: $protocol"


### PR DESCRIPTION
## Description
When reading protocol information from openvpn config files, remap to "tcp-client" to "tcp".

## Motivation and Context
Openvpn configs specify protocol as either udp, tcp-client or tcp-server
iptables doesn't know what to do with "tcp-client" and spits out this message:
``` iptables v1.8.7 (legacy): unknown protocol "tcp-client" specified ```
Doesn't halt the script but it does not add the intended iptables rule as-is.
tcp-server shouldn't be specified in a client's configuration and won't need handling, AFAICT.
From what I've read UDP is preferred & TCP isn't generally recommended for OpenVPN but acceptable as a fallback if UDP fails.
I assume that if someone was connecting solely via TCP the container would be unable to make the outbound connection.

## How Has This Been Tested?

Built a container locally with and without the changes.

Before changes iptables --list outputs:
```
Chain INPUT (policy DROP)
target     prot opt source               destination
ACCEPT     all  --  anywhere             anywhere             ctstate RELATED,ESTABLISHED
ACCEPT     all  --  anywhere             anywhere
ACCEPT     all  --  172.30.0.0/16        anywhere
ACCEPT     all  --  anywhere             anywhere

Chain FORWARD (policy DROP)
target     prot opt source               destination

Chain OUTPUT (policy DROP)
target     prot opt source               destination
ACCEPT     all  --  anywhere             anywhere
ACCEPT     all  --  anywhere             172.30.0.0/16
ACCEPT     udp  --  anywhere             remotehost             udp dpt:openvpn
ACCEPT     all  --  anywhere             anywhere
```
With my change:
```
Chain INPUT (policy DROP)
target     prot opt source               destination
ACCEPT     all  --  anywhere             anywhere             ctstate RELATED,ESTABLISHED
ACCEPT     all  --  anywhere             anywhere
ACCEPT     all  --  172.30.0.0/16        anywhere
ACCEPT     all  --  anywhere             anywhere

Chain FORWARD (policy DROP)
target     prot opt source               destination

Chain OUTPUT (policy DROP)
target     prot opt source               destination
ACCEPT     all  --  anywhere             anywhere
ACCEPT     all  --  anywhere             172.30.0.0/16
ACCEPT     udp  --  anywhere             remotehost             udp dpt:openvpn
ACCEPT     tcp  --  anywhere             remotehost             tcp dpt:https
ACCEPT     all  --  anywhere             anywhere
```
Key difference being:
```ACCEPT     tcp  --  anywhere             remotehost             tcp dpt:https```


## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.

Probably doesn't need a documentation update beyond the comment?
I couldn't find any tests.