### PR TITLE
Make sure there are always up/down commands in OpenVPN configuration file

### DIFF
--- a/data/scripts/entry.sh
+++ b/data/scripts/entry.sh
@@ -53,7 +53,7 @@ echo "Using configuration file: $config_file_original"
 config_file_modified="${config_file_original}.modified"
 
 echo "Creating $config_file_modified and making required changes to that file."
-grep -Ev "(^up \s|^down \s)" "$config_file_original" > "$config_file_modified"
+grep -Ev "(^up\s|^down\s)" "$config_file_original" > "$config_file_modified"
 
 # These configuration file changes are required by Alpine.
 sed -i \

--- a/data/scripts/entry.sh
+++ b/data/scripts/entry.sh
@@ -53,15 +53,16 @@ echo "Using configuration file: $config_file_original"
 config_file_modified="${config_file_original}.modified"
 
 echo "Creating $config_file_modified and making required changes to that file."
-cp "$config_file_original" "$config_file_modified"
+grep -Ev "(^up \s|^down \s)" "$config_file_original" > "$config_file_modified"
 
 # These configuration file changes are required by Alpine.
 sed -i \
-    -e '/up /c up \/etc\/openvpn\/up.sh' \
-    -e '/down /c down \/etc\/openvpn\/down.sh' \
     -e 's/^proto udp$/proto udp4/' \
     -e 's/^proto tcp$/proto tcp4/' \
     "$config_file_modified"
+
+echo "up /etc/openvpn/up.sh" >> "$config_file_modified"
+echo "down /etc/openvpn/down.sh" >> "$config_file_modified"
 
 echo -e "Changes made.\n"
 


### PR DESCRIPTION
If generated `.ovpn` configuration doesn't have `up ...` or `down ...` commands, they will never be replaced with `sed` and DNS resolution isn't going to work.