### PR TITLE
Add KEEP_DNS_UNCHANGED environment variable that allows to keep /etc/resolv.conf unchanged

### DIFF
--- a/data/scripts/entry.sh
+++ b/data/scripts/entry.sh
@@ -31,6 +31,7 @@ echo "
 Kill switch: ${KILL_SWITCH:-off}
 HTTP proxy: ${HTTP_PROXY:-off}
 SOCKS proxy: ${SOCKS_PROXY:-off}
+Keep /etc/resolv.conf unchanged: ${KEEP_DNS_UNCHANGED:-no}
 Proxy username secret: ${PROXY_PASSWORD_SECRET:-none}
 Proxy password secret: ${PROXY_USERNAME_SECRET:-none}
 Allowing subnets: ${SUBNETS:-none}
@@ -66,8 +67,10 @@ sed -i \
     -e 's/^proto tcp$/proto tcp4/' \
     "$config_file_modified"
 
-echo "up /etc/openvpn/up.sh" >> "$config_file_modified"
-echo "down /etc/openvpn/down.sh" >> "$config_file_modified"
+if [[ "$KEEP_DNS_UNCHANGED" != "yes" ]]; then 
+    echo "up /etc/openvpn/up.sh" >> "$config_file_modified"
+    echo "down /etc/openvpn/down.sh" >> "$config_file_modified"
+fi
 
 echo -e "Changes made.\n"
 


### PR DESCRIPTION
### Background:

I want to run Firefox in Docker container connected to the VPN. To do this, I use `wfg/openvpn-client` + `jess/firefox` containers. `jess/firefox` uses X11 forwarding so I can access Firefox GUI on the host. 

For the forwarding I need to define `$DISPLAY` env variable inside `jess/firefox` container in the format `<host-ip>:0`. So I need to somehow get the host IP from Docker container. As I use Docker on macOS, I can use special domain name `host.docker.internal`. Except, this domain name couldn't be resolved when `jess/firefox` is connected to the Internet via `wfg/openvpn-client`.

### Problem:
When container is connected to the Internet via `wfg/openvpn-client`, it can't ping other containers using their Docker names (i.e. names in docker-compose.yml or names given when container was created), or ping special Docker host names (such as `host.docker.internal`).

This is because `openvpn-client` image modifies DNS settings of the container - modifies `/etc/resolv.conf` file, overwriting default Docker DNS server, which is used to resolve such special names as `host.docker.internal`. 

### Possible solution:

I would like to use the original DNS server in the container, so I've added `$KEEP_DNS_UNCHANGED` env variable and tweaked ENTRYPOINT script of this image. 

When `$KEEP_DNS_UNCHANGED` is set to 'yes', the script simply doesn't add `up.sh` and `down.sh` scripts to the openvpn config, so DNS settings are not modified (see https://github.com/wfg/docker-openvpn-client/blob/master/data/scripts/entry.sh#L69). 

When I use `$KEEP_DNS_UNCHANDED=yes`, '$KILL_SWITCH=on` and `$SUBNETS=192.168.65.0/24`, I can successfully ping `host.docker.internal` form my container.

(192.168.65.0/24 is Docker Subnet on my computer. It looks live Docker internal DNS server is located on this network, as `host.docker.internal` doesn't resolve when I don't allow the container to connect to this network. See https://stackoverflow.com/questions/62849480/what-is-the-docker-subnet-used-for)

So, it might be useful to have such variable, though there might be some problems in keeping original DNS settings while using OpenVPN that I am not aware of.