### PR TITLE
fix(socks): user already exists

### DIFF
--- a/data/scripts/run-socks-proxy.sh
+++ b/data/scripts/run-socks-proxy.sh
@@ -13,11 +13,11 @@ if [[ $SOCKS_LISTEN_ON ]]; then
 fi
 if [[ $SOCKS_PROXY_USERNAME && $SOCKS_PROXY_PASSWORD ]]; then
     printf 'info: starting socks proxy with credentials\n'
-    useradd "$SOCKS_PROXY_USERNAME" -s /bin/false -M -p "$(mkpasswd "$SOCKS_PROXY_PASSWORD")"
+    id -u "$SOCKS_PROXY_USERNAME" &>/dev/null || useradd "$SOCKS_PROXY_USERNAME" -s /bin/false -M -p "$(mkpasswd "$SOCKS_PROXY_PASSWORD")"
     sed -i "/method: /c method: username" $proxy_config_file
 elif [[ -f "/run/secrets/$SOCKS_PROXY_USERNAME_SECRET" && -f "/run/secrets/$SOCKS_PROXY_PASSWORD_SECRET" ]]; then
     printf 'info: starting socks proxy with credentials\n'
-    useradd "$(cat /run/secrets/"$SOCKS_PROXY_USERNAME_SECRET")" -s /bin/false -M -p "$(mkpasswd "$(cat /run/secrets/"$SOCKS_PROXY_PASSWORD_SECRET")")"
+    id -u "$(cat /run/secrets/"$SOCKS_PROXY_USERNAME_SECRET")" &>/dev/null || useradd "$(cat /run/secrets/"$SOCKS_PROXY_USERNAME_SECRET")" -s /bin/false -M -p "$(mkpasswd "$(cat /run/secrets/"$SOCKS_PROXY_PASSWORD_SECRET")")"
     sed -i "/method: /c method: username" $proxy_config_file
 else
     printf 'info: starting socks proxy without credentials\n'

--- a/data/scripts/run-socks-proxy.sh
+++ b/data/scripts/run-socks-proxy.sh
@@ -13,11 +13,11 @@ if [[ $SOCKS_LISTEN_ON ]]; then
 fi
 if [[ $SOCKS_PROXY_USERNAME && $SOCKS_PROXY_PASSWORD ]]; then
     printf 'info: starting socks proxy with credentials\n'
-    id -u "$SOCKS_PROXY_USERNAME" &>/dev/null || useradd "$SOCKS_PROXY_USERNAME" -s /bin/false -M -p "$(mkpasswd "$SOCKS_PROXY_PASSWORD")"
+    id "$SOCKS_PROXY_USERNAME" &> /dev/null || useradd "$SOCKS_PROXY_USERNAME" -s /bin/false -M -p "$(mkpasswd "$SOCKS_PROXY_PASSWORD")"
     sed -i "/method: /c method: username" $proxy_config_file
 elif [[ -f "/run/secrets/$SOCKS_PROXY_USERNAME_SECRET" && -f "/run/secrets/$SOCKS_PROXY_PASSWORD_SECRET" ]]; then
     printf 'info: starting socks proxy with credentials\n'
-    id -u "$(cat /run/secrets/"$SOCKS_PROXY_USERNAME_SECRET")" &>/dev/null || useradd "$(cat /run/secrets/"$SOCKS_PROXY_USERNAME_SECRET")" -s /bin/false -M -p "$(mkpasswd "$(cat /run/secrets/"$SOCKS_PROXY_PASSWORD_SECRET")")"
+    id "$(cat /run/secrets/"$SOCKS_PROXY_USERNAME_SECRET")" &> /dev/null || useradd "$(cat /run/secrets/"$SOCKS_PROXY_USERNAME_SECRET")" -s /bin/false -M -p "$(mkpasswd "$(cat /run/secrets/"$SOCKS_PROXY_PASSWORD_SECRET")")"
     sed -i "/method: /c method: username" $proxy_config_file
 else
     printf 'info: starting socks proxy without credentials\n'


### PR DESCRIPTION
avoid reporting an error after restart container and causing sockd not to start