### PR TITLE
podman  Support + performance tunes + misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,16 +99,15 @@ services:
 | `SOCKS_PROXY_USERNAME_SECRET` |                          | Docker secrets that contain the credentials for accessing the proxies. If `SOCKS_PROXY_USERNAME_SECRET` is specified, you should also specify `SOCKS_PROXY_PASSWORD_SECRET`.                                                                                     |
 | `SOCKS_PROXY_PASSWORD_SECRET` |                          | Docker secrets that contain the credentials for accessing the proxies. If `SOCKS_PROXY_PASSWORD_SECRET` is specified, you should also specify `SOCKS_PROXY_USERNAME_SECRET`.                                                                                     |
 | `RETRY`                       | `5`                      | Seconds to wait between connection attempts - see `openvpn`, first argument to `--connect-retry`.                                                                                                                                                                |
-| `MAX_RETRY`                   | `60`                     | Repeated reconnection attempts are slowed down after 5 retries per remote by doubling the wait time after each unsuccessful attempt.  The script caps at `60` - see `openvpn`, second argument to `--connect-retry`.                                             |
-| `SERVER_POLL`                 | `120`                    | When connecting to a remote server do not wait for more than n seconds for a response before trying the next server - see `openvpn`, `--server-poll-timeout`.                                                                                                    |
-| `PING`                        | `15`                     | Ping remote over the TCP/UDP control channel if no packets have been sent for at least `n` seconds - see `openvpn`, `--ping`                                                                                                                                     |
-| `PING_RESTART`                | `120`                    | Similar to `--ping-exit`, but trigger a `SIGUSR1` restart after n seconds pass without reception of a ping or other packet  from remote - see `openvpn`, `--ping-restart`.                                                                                       |
+| `MAX_RETRY`                   | `60`                     | Repeated reconnection attempts are slowed down after 5 retries per remote by doubling the wait time after each unsuccessful attempt.  The script caps at `60` seconds - see `openvpn`, second argument to `--connect-retry`.                                     |
+| `SERVER_POLL`                 | `120`                    | When connecting to a remote server do not wait for more than `n` seconds for a response before trying the next server - see `openvpn`, `--server-poll-timeout`.                                                                                                  |
+| `PING`                        | `15`                     | Ping remote over the TCP/UDP control channel if no packets have been sent for at least `n` seconds - see `openvpn`, `--ping`.                                                                                                                                    |
+| `PING_RESTART`                | `120`                    | Similar to `--ping-exit`, but trigger a `SIGUSR1` restart after `n` seconds pass without reception of a ping or other packet  from remote - see `openvpn`, `--ping-restart`.                                                                                     |
 | `TAP`                         | `eth0`                   | Use this option to remap the script's `eth0` device.                                                                                                                                                                                                             |
 | `USE_FAST_IO`                 |                          | (Experimental) Optimize TUN/TAP/UDP I/O writes - see `openvpn`, `--fast-io`.                                                                                                                                                                                     |
 | `SNDBUF`                      |                          | Set the TCP/UDP socket send buffer size - see `openvpn`, `--sndbuf`.                                                                                                                                                                                             |
 | `RCVBUF`                      |                          | Set the TCP/UDP socket receive buffer size - see `openvpn`, `--rcvbuf`.                                                                                                                                                                                          |
-| `DEBUG_VPN_CONFIG_FILE`       |                          | The container creates a modified version of the VPN file.  When debugging, it may be helpful to preserve the file.  Use this option to have it saved in your VPN directory.  It is named `openvpn.XXXXXXXX.conf`.                                                |
-|                               |                          |                                                                                                                                                                                                                                                                  |
+| `DEBUG_VPN_CONFIG_FILE`       |                          | The container creates a modified version of the VPN file.  When debugging, it may be helpful to preserve this file.  The option saves the modified file in your VPN directory.  It is named `openvpn.XXXXXXXX.conf`.                                             |
 "Truthy" values are the following: `true`, `t`, `yes`, `y`, `1`, `on`, `enable`, or `enabled`.
 
 ##### Environment variable considerations
@@ -169,7 +168,8 @@ The following parameters may provide some performance benefits:
 * `SNDBUF`
 * `RCVBUF`
 
-In general, run three tests in (near) isolation with one tune set.
+In general, run three tests in (near) isolation with one tune set before
+adding another.
 
 ### Tips
 
@@ -210,14 +210,12 @@ Change the permissions so only your user has read/write permissions:
 ```shell
 $ chmod 600 credentials.txt
 ```
-
 ##### Method 1 
 `run` the container with the following additional parameters:
 ```
   --env VPN_AUTH_SECRET="credentials.txt" \
   --volume <path/to/config/dir>:/run/secrets" \
 ```
-
 ##### Method 2
 In the OpenVPN configuration file, add the following line:
 ```

--- a/README.md
+++ b/README.md
@@ -105,8 +105,6 @@ services:
 | `PING_RESTART`                | `120`                    | Similar to `--ping-exit`, but trigger a `SIGUSR1` restart after `n` seconds pass without reception of a ping or other packet  from remote - see `openvpn`, `--ping-restart`.                                                                                     |
 | `TAP`                         | `eth0`                   | Use this option to remap the script's `eth0` device.                                                                                                                                                                                                             |
 | `USE_FAST_IO`                 |                          | (Experimental) Optimize TUN/TAP/UDP I/O writes - see `openvpn`, `--fast-io`.                                                                                                                                                                                     |
-| `SNDBUF`                      |                          | Set the TCP/UDP socket send buffer size - see `openvpn`, `--sndbuf`.                                                                                                                                                                                             |
-| `RCVBUF`                      |                          | Set the TCP/UDP socket receive buffer size - see `openvpn`, `--rcvbuf`.                                                                                                                                                                                          |
 | `DEBUG_VPN_CONFIG_FILE`       |                          | The container creates a modified version of the VPN file.  When debugging, it may be helpful to preserve this file.  When the option is enabled, the modified file is created in your VPN directory with the name-pattern `openvpn.XXXXXXXX.conf`.               |
 "Truthy" values are the following: `true`, `t`, `yes`, `y`, `1`, `on`, `enable`, or `enabled`.
 
@@ -162,14 +160,9 @@ docker run --rm -it --network=container:openvpn-client alpine wget -qO - ifconfi
 ```
 
 ### Performance tuning
-The following parameters may provide some performance benefits:
+The following parameter may provide some performance benefits:
 
-* `USE_FAST_IO`
-* `SNDBUF`
-* `RCVBUF`
-
-In general, run three tests in (near) isolation with one tune set before
-adding another.
+* `USE_FAST_IO` - non-Windows
 
 ### Tips
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ It also keeps you from having to install an OpenVPN client on the underlying hos
 
 ## How do I use it?
 ### Podman users
-Unless noted, all that is required is that you use `podman` in place of
-`docker`.
+Unless noted, below use `podman` in place of `docker`.
 
 ### Getting the image
 You can either pull it from GitHub Container Registry or build it yourself.
@@ -49,11 +48,10 @@ docker run --detach \
 
 #### `podman run`
 * Use `--privileged` - see [podman run](https://docs.podman.io/en/latest/markdown/podman-run.1.html).
-* Use `--env TAP="tap0"` to override the default `eth0` device to
-  `tap0`.  Confirm `tap0` with `podman logs openvpn-client`
+* Use `--env TAP="tap0"` to override the internal script's `eth0` with `tap0`.
 
 ```bash
-docker run --detach \
+podman run --detach \
   --privileged \
   --env TAP="tap0" \
   --name=openvpn-client \
@@ -88,7 +86,7 @@ services:
 | `VPN_LOG_LEVEL`               | `3`                      | OpenVPN logging verbosity (`1`-`11`)                                                                                                                                                                                                                             |
 | `SUBNETS`                     |                          | A list of one or more comma-separated subnets (e.g. `192.168.0.0/24,192.168.1.0/24`) to allow outside of the VPN tunnel.                                                                                                                                         |
 | `KILL_SWITCH`                 | `iptables`               | Which packet filterer to use for the kill switch. This value likely depends on your underlying host. Recommended to leave default unless you have problems. Acceptable values are `iptables` and `nftables`. To disable the kill switch, set to any other value. |
-| `DIG_TIMEOUT`                 | `5`                      | When `KILL_SWITCH` is enabled, `dig`s timeout.                                                                                                                                                                                                                   |
+| `DIG_TIMEOUT`                 | `5`                      | When `KILL_SWITCH` is enabled, `dig`'s timeout.                                                                                                                                                                                                                  |
 | `HTTP_PROXY`                  |                          | Whether or not to enable the built-in HTTP proxy server. To enable, set to any "truthy" value (see below the table). Any other value (including unset) will cause the proxy server to not run. It listens on port 8080.                                          |
 | `HTTP_PROXY_USERNAME`         |                          | Credentials for accessing the HTTP proxy. If `HTTP_PROXY_USERNAME` is specified, you should also specify `HTTP_PROXY_PASSWORD`.                                                                                                                                  |
 | `HTTP_PROXY_PASSWORD`         |                          | Credentials for accessing the HTTP proxy. If `HTTP_PROXY_PASSWORD` is specified, you should also specify `HTTP_PROXY_USERNAME`.                                                                                                                                  |
@@ -103,8 +101,8 @@ services:
 | `RETRY`                       | `5`                      | Seconds to wait between connection attempts - see `openvpn`, first argument to `--connect-retry`.                                                                                                                                                                |
 | `MAX_RETRY`                   | `60`                     | Repeated reconnection attempts are slowed down after 5 retries per remote by doubling the wait time after each unsuccessful attempt.  The script caps at `60` - see `openvpn`, second argument to `--connect-retry`.                                             |
 | `SERVER_POLL`                 | `120`                    | When connecting to a remote server do not wait for more than n seconds for a response before trying the next server - see `openvpn`, `--server-poll-timeout`.                                                                                                    |
-| `PING`                        | `15`                     | Ping remote over the TCP/UDP control channel if no packets have been sent for at least n seconds - see `openvpn`, `--ping`                                                                                                                                       |
-| `PING_RESTART`                | `120`                    | Similar to --ping-exit, but trigger a SIGUSR1 restart after n seconds pass without reception of a ping or other packet  from remote - see `openvpn`, `--ping-restart`.                                                                                           |
+| `PING`                        | `15`                     | Ping remote over the TCP/UDP control channel if no packets have been sent for at least `n` seconds - see `openvpn`, `--ping`                                                                                                                                     |
+| `PING_RESTART`                | `120`                    | Similar to `--ping-exit`, but trigger a `SIGUSR1` restart after n seconds pass without reception of a ping or other packet  from remote - see `openvpn`, `--ping-restart`.                                                                                       |
 | `TAP`                         | `eth0`                   | Use this option to remap the script's `eth0` device.                                                                                                                                                                                                             |
 | `USE_FAST_IO`                 |                          | (Experimental) Optimize TUN/TAP/UDP I/O writes - see `openvpn`, `--fast-io`.                                                                                                                                                                                     |
 | `SNDBUF`                      |                          | Set the TCP/UDP socket send buffer size - see `openvpn`, `--sndbuf`.                                                                                                                                                                                             |
@@ -171,7 +169,7 @@ The following parameters may provide some performance benefits:
 * `SNDBUF`
 * `RCVBUF`
 
-In general, run several tests with one tune set.
+In general, run three tests in (near) isolation with one tune set.
 
 ### Tips
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ services:
 | `USE_FAST_IO`                 |                          | (Experimental) Optimize TUN/TAP/UDP I/O writes - see `openvpn`, `--fast-io`.                                                                                                                                                                                     |
 | `SNDBUF`                      |                          | Set the TCP/UDP socket send buffer size - see `openvpn`, `--sndbuf`.                                                                                                                                                                                             |
 | `RCVBUF`                      |                          | Set the TCP/UDP socket receive buffer size - see `openvpn`, `--rcvbuf`.                                                                                                                                                                                          |
-| `DEBUG_VPN_CONFIG_FILE`       |                          | The container creates a modified version of the VPN file.  When debugging, it may be helpful to preserve this file.  The option saves the modified file in your VPN directory.  It is named `openvpn.XXXXXXXX.conf`.                                             |
+| `DEBUG_VPN_CONFIG_FILE`       |                          | The container creates a modified version of the VPN file.  When debugging, it may be helpful to preserve this file.  When the option is enabled, the modified file is created in your VPN directory with the name-pattern `openvpn.XXXXXXXX.conf`.               |
 "Truthy" values are the following: `true`, `t`, `yes`, `y`, `1`, `on`, `enable`, or `enabled`.
 
 ##### Environment variable considerations

--- a/data/scripts/entry.sh
+++ b/data/scripts/entry.sh
@@ -157,7 +157,7 @@ setup_kill_switch() {
                      iptables -A OUTPUT -o "${TAP:-eth0}" -d "$ip" -p "$protocol" --dport "$port" -j ACCEPT
                      printf "%s %s\n" "$ip" "$address" >> /etc/hosts
                   else
-                     log_msg "dig returned malformed IP ($IP).  Cannot recover. Bye."
+                     log_msg "dig returned malformed IP ($ip).  Cannot recover. Bye."
                      exit 1
                   fi
                done
@@ -204,7 +204,7 @@ setup_kill_switch() {
          fi
 
          global_port=$(grep "^port " "$modified_config_file" | awk '{print $2}')
-         global_protocol=$(grep "^proto " "$modified_config_file" | awk '{print $2}')  # {$2 = substr($2, 1, 3)} 2
+         global_protocol=$(grep "^proto " "$modified_config_file" | awk '{print $2}')
          remotes=$(grep "^remote " "$modified_config_file" | awk '{print $2, $3, $4}')
 
          printf '# allow traffic to the VPN server(s)\n' >> $nftables_config_file

--- a/data/scripts/entry.sh
+++ b/data/scripts/entry.sh
@@ -52,7 +52,7 @@ dump_user_settings() {
    else
       log_msg "Container script 'eth0' not remapped."
    fi
-   if [[ -n "$USE_FAST_IO" ]] ; then
+   if is_enabled "$USE_FAST_IO" ; then
       log_msg "Fast IO enabled (--fast-io), a non-Windows, UDP-only switch"
    fi
    if [[ -n "$SNDBUF" ]] ; then
@@ -82,7 +82,7 @@ dump_user_settings() {
       fi
    fi
 
-   if [[ -n "$DEBUG_VPN_CONFIG_FILE" ]] ; then
+   if is_enabled "$DEBUG_VPN_CONFIG_FILE" ; then
       log_msg "Keeping modified .ovpn file with source .ovpn file"
    fi
 }
@@ -109,7 +109,7 @@ gen_working_VPN_file() {
    # Use the passed in $DEBUG_VPN_CONFIG_FILE variable to determine whether
    # the modified file is ephemeral or not.
    MOD_DIR="/tmp"
-   if [[ -n "$DEBUG_VPN_CONFIG_FILE" ]] ; then
+   if is_enabled "$DEBUG_VPN_CONFIG_FILE" ; then
       MOD_DIR="vpn"
    fi
    MODIFIED_CONFIG_FILE=$MOD_DIR/openvpn.$(tr -dc A-Za-z0-9 </dev/urandom | head -c8).conf

--- a/data/scripts/entry.sh
+++ b/data/scripts/entry.sh
@@ -2,241 +2,349 @@
 
 set -e
 
+BASENAME=$(basename "$0")
+log_msg() {
+   echo -e "$(date +'%F %T')" ["$BASENAME"] "$@"
+}
 
 cleanup() {
-    if [[ $openvpn_child ]]; then
-        kill SIGTERM "$openvpn_child"
-    fi
-
-    sleep 0.5
-    rm -f "$modified_config_file"
-    echo "info: exiting"
-    exit 0
+   if [[ -n "$OPENVPN_CHILD" ]]; then
+      log_msg "Asking openvpn to exit gracefully"
+      kill SIGTERM $OPENVPN_CHILD > /dev/null 2>&1
+      I=15
+      while [[ $I -ge 0 ]] ; do
+         kill -0 $OPENVPN_CHILD > /dev/null 2>&1
+         if [[ $? -eq 1 ]] ; then
+            break
+         fi
+         log_msg "Waiting on openvpn to end ... $I"
+         sleep 1
+         ((I--))
+      done
+   fi
 }
 
 is_enabled() {
-    [[ ${1,,} =~ ^(true|t|yes|y|1|on|enable|enabled)$ ]]
+   [[ ${1,,} =~ ^(true|t|yes|y|1|on|enable|enabled)$ ]]
 }
+
+dump_user_settings() {
+   log_msg "User settings"
+   log_msg "============="
+
+   if [[ $VPN_CONFIG_FILE ]]; then
+      log_msg "VPN configuration file: $VPN_CONFIG_FILE"
+   fi
+   if [[ $VPN_CONFIG_PATTERN ]]; then
+      log_msg "VPN configuration file name pattern: $VPN_CONFIG_PATTERN"
+   fi
+
+   log_msg "Use default resolv.conf: ${USE_VPN_DNS:-off}"
+   log_msg "Allowing subnets: ${SUBNETS:-none}"
+   log_msg "Kill switch method: $KILL_SWITCH"
+   log_msg "Connect retry (--connect-retry): ${RETRY:-5} ${MAX_RETRY:-60} second(s)"
+   log_msg "Server poll timeout (--server-poll-timeout): ${SERVER_POLL:-120}"
+   log_msg "Ping (--ping): ${PING:-15}"
+   log_msg "Ping restart (--ping-restart): ${PING_RESTART:-120}"
+   log_msg "Using OpenVPN log level: $VPN_LOG_LEVEL"
+   if [[ -n "$TAP" ]] ; then
+      log_msg "Container script 'eth0' remapped to '${TAP}'"
+   else
+      log_msg "Container script 'eth0' not remapped."
+   fi
+   if [[ -n "$USE_FAST_IO" ]] ; then
+      log_msg "Fast IO enabled (--fast-io), a non-Windows, UDP-only switch"
+   fi
+   if [[ -n "$SNDBUF" ]] ; then
+      log_msg "Send buffer (--sndbuf): ${SNDBUF}"
+   fi
+   if [[ -n "$RCVBUF" ]] ; then
+      log_msg "Receive buffer (--sndbuf): ${RCVBUF}"
+   fi
+
+   if is_enabled "$HTTP_PROXY"; then
+      log_msg "HTTP proxy: $HTTP_PROXY"
+      if is_enabled "$HTTP_PROXY_USERNAME"; then
+         log_msg "HTTP proxy username: $HTTP_PROXY_USERNAME"
+      elif is_enabled "$HTTP_PROXY_USERNAME_SECRET"; then
+         log_msg "HTTP proxy username secret: $HTTP_PROXY_USERNAME_SECRET"
+      fi
+   fi
+   if is_enabled "$SOCKS_PROXY"; then
+      log_msg "SOCKS proxy: $SOCKS_PROXY"
+      if [[ $SOCKS_LISTEN_ON ]]; then
+         log_msg "SOCKS istening on: $SOCKS_LISTEN_ON"
+      fi
+      if is_enabled "$SOCKS_PROXY_USERNAME"; then
+         log_msg "SOCKS proxy username: $SOCKS_PROXY_USERNAME"
+      elif is_enabled "$SOCKS_PROXY_USERNAME_SECRET"; then
+         log_msg "SOCKS proxy username secret: $SOCKS_PROXY_USERNAME_SECRET"
+      fi
+   fi
+
+   if [[ -n "$DEBUG_VPN_CONFIG_FILE" ]] ; then
+      log_msg "Keeping modified .ovpn file with source .ovpn file"
+   fi
+}
+
+gen_working_VPN_file() {
+   if [[ $VPN_CONFIG_FILE ]]; then
+      ORIGINAL_CONFIG_FILE=vpn/$VPN_CONFIG_FILE
+   elif [[ $VPN_CONFIG_PATTERN ]]; then
+      ORIGINAL_CONFIG_FILE=$(find vpn -name "$VPN_CONFIG_PATTERN" 2> /dev/null | sort | shuf -n 1)
+   else
+      ORIGINAL_CONFIG_FILE=$(find vpn -name '*.conf' -o -name '*.ovpn' 2> /dev/null | sort | shuf -n 1)
+   fi
+
+   if [[ ! -f $ORIGINAL_CONFIG_FILE ]]; then
+      >&2 log_msg "erro: no vpn configuration file found"
+      exit 1
+   fi
+
+   log_msg "info: original configuration file: $ORIGINAL_CONFIG_FILE"
+
+   # Create a new configuration file to modify so the original is left
+   # untouched.
+   #
+   # Use the passed in $DEBUG_VPN_CONFIG_FILE variable to determine whether
+   # the modified file is ephemeral or not.
+   MOD_DIR="/tmp"
+   if [[ -n "$DEBUG_VPN_CONFIG_FILE" ]] ; then
+      MOD_DIR="vpn"
+   fi
+   MODIFIED_CONFIG_FILE=$MOD_DIR/openvpn.$(tr -dc A-Za-z0-9 </dev/urandom | head -c8).conf
+
+   log_msg "info: modified configuration file: $MODIFIED_CONFIG_FILE"
+   grep -Ev '(^up\s|^down\s)' "$ORIGINAL_CONFIG_FILE" > "$MODIFIED_CONFIG_FILE"
+
+   # Remove carriage returns (\r) from the config file
+   sed -i 's/\r$//g' "$MODIFIED_CONFIG_FILE"
+}
+
+setup_kill_switch() {
+   DEFAULT_GATEWAY=$(ip -4 route | grep 'default via' | awk '{print $3}')
+   case "$KILL_SWITCH" in
+      'iptables')
+         log_msg "Configuring $KILL_SWITCH kill switch"
+
+         iptables -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+         iptables -A INPUT -i lo -j ACCEPT
+         iptables -A OUTPUT -o lo -j ACCEPT
+
+         LOCAL_SUBNET=$(ip -4 route | grep 'scope link' | awk '{print $1}')
+         iptables -A INPUT -s "$LOCAL_SUBNET" -j ACCEPT
+         iptables -A OUTPUT -d "$LOCAL_SUBNET" -j ACCEPT
+
+         if [[ $SUBNETS ]]; then
+            for SUBNET in ${SUBNETS//,/ }; do
+               ip route add "$SUBNET" via "$DEFAULT_GATEWAY" dev "${TAP:-eth0}"
+               iptables -A INPUT -s "$SUBNET" -j ACCEPT
+               iptables -A OUTPUT -d "$SUBNET" -j ACCEPT
+            done
+         fi
+
+         GLOBAL_PORT=$(grep "^port " "$MODIFIED_CONFIG_FILE" | awk '{print $2}')
+         GLOBAL_PROTOCOL=$(grep "^proto " "$MODIFIED_CONFIG_FILE" | awk '{print $2}')  # {$2 = substr($2, 1, 3)} 2
+         REMOTES=$(grep "^remote " "$MODIFIED_CONFIG_FILE" | awk '{print $2, $3, $4}')
+         IP_REGEX='^(([1-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))\.){3}([1-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))$'
+         while IFS= read -r LINE; do
+            IFS=' ' read -ra REMOTE <<< "$LINE"
+            ADDRESS=${REMOTE[0]}
+            PORT=${REMOTE[1]:-${GLOBAL_PORT:-1194}}
+            PROTOCOL=${REMOTE[2]:-${GLOBAL_PROTOCOL:-udp}}
+
+            if [[ $ADDRESS =~ $IP_REGEX ]]; then
+               iptables -A OUTPUT -o "${TAP:-eth0}" -d "$ADDRESS" -p "$PROTOCOL" --dport "$PORT" -j ACCEPT
+            else
+               log_msg "dig lookup on $ADDRESS"
+               for IP in $(dig -4 +timeout="${DIG_TIMEOUT:-5}" +tries=1 +short "$ADDRESS"); do
+                  if echo "$IP" | grep -s '^[0-9]' > /dev/null 2>&1 ; then
+                     iptables -A OUTPUT -o "${TAP:-eth0}" -d "$IP" -p "$PROTOCOL" --dport "$PORT" -j ACCEPT
+                     printf "%s %s\n" "$IP" "$ADDRESS" >> /etc/hosts
+                  else
+                     log_msg "dig returned malformed IP ($IP).  Cannot recover. Bye."
+                     exit 1
+                  fi
+               done
+            fi
+         done <<< "$REMOTES"
+         iptables -A INPUT -i tun0 -j ACCEPT
+         iptables -A OUTPUT -o tun0 -j ACCEPT
+         iptables -P INPUT DROP
+         iptables -P OUTPUT DROP
+         iptables -P FORWARD DROP
+         iptables-save > config/iptables.conf
+         ;;
+      'nftables')
+         log_msg "Configuring $KILL_SWITCH kill switch"
+
+         NFTABLES_CONFIG_FILE=config/nftables.conf
+
+         printf '%s\n' \
+                '#!/usr/bin/nft' '' \
+                'flush ruleset' '' \
+                '# base ruleset' \
+                'add table inet killswitch' '' \
+                'add chain inet killswitch incoming { type filter hook input priority 0; policy drop; }' \
+                'add rule inet killswitch incoming ct state established,related accept' \
+                'add rule inet killswitch incoming iifname lo accept' '' \
+                'add chain inet killswitch outgoing { type filter hook output priority 0; policy drop; }' \
+                'add rule inet killswitch outgoing ct state established,related accept' \
+                'add rule inet killswitch outgoing oifname lo accept' '' > $NFTABLES_CONFIG_FILE
+
+         LOCAL_SUBNET=$(ip -4 route | grep 'scope link' | awk '{print $1}')
+         printf '%s\n' \
+                '# allow traffic to/from the Docker subnet' \
+                "add rule inet killswitch incoming ip saddr $LOCAL_SUBNET accept" \
+                "add rule inet killswitch outgoing ip daddr $LOCAL_SUBNET accept" '' >> $NFTABLES_CONFIG_FILE
+
+         if [[ $SUBNETS ]]; then
+            printf '# allow traffic to/from the specified subnets\n' >> $NFTABLES_CONFIG_FILE
+            for subnet in ${SUBNETS//,/ }; do
+               ip route add "$subnet" via "$DEFAULT_GATEWAY" dev "${TAP:-eth0}"
+               printf '%s\n' \
+                      "add rule inet killswitch incoming ip saddr $subnet accept" \
+                      "add rule inet killswitch outgoing ip daddr $subnet accept" '' >> $NFTABLES_CONFIG_FILE
+            done
+         fi
+
+         GLOBAL_PORT=$(grep "^port " "$MODIFIED_CONFIG_FILE" | awk '{print $2}')
+         GLOBAL_PROTOCOL=$(grep "^proto " "$MODIFIED_CONFIG_FILE" | awk '{print $2}')  # {$2 = substr($2, 1, 3)} 2
+         REMOTES=$(grep "^remote " "$MODIFIED_CONFIG_FILE" | awk '{print $2, $3, $4}')
+
+         printf '# allow traffic to the VPN server(s)\n' >> $NFTABLES_CONFIG_FILE
+         IP_REGEX='^(([1-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))\.){3}([1-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))$'
+         while IFS= read -r LINE; do
+            IFS=' ' read -ra REMOTE <<< "$LINE"
+            ADDRESS=${REMOTE[0]}
+            PORT=${REMOTE[1]:-${GLOBAL_PORT:-1194}}
+            PROTOCOL=${REMOTE[2]:-${GLOBAL_PROTOCOL:-udp}}
+
+            if [[ $ADDRESS =~ $IP_REGEX ]]; then
+               printf '%s\n' \
+                      "add rule inet killswitch outgoing oifname ${TAP:-eth0} ip daddr $ADDRESS $PROTOCOL dport $PORT accept" >> $NFTABLES_CONFIG_FILE
+            else
+               log_msg "dig lookup on $ADDRESS"
+               for IP in $(dig -4 +timeout="${DIG_TIMEOUT:-5}" +tries=1 +short "$ADDRESS"); do
+                  if echo "$IP" | grep -s '^[0-9]' > /dev/null 2>&1 ; then
+                     printf '%s\n' \
+                            "add rule inet killswitch outgoing oifname ${TAP:-eth0} ip daddr $IP $PROTOCOL dport $PORT accept" >> $NFTABLES_CONFIG_FILE
+                     printf "%s %s\n" "$IP" "$ADDRESS" >> /etc/hosts
+                  else
+                     log_msg "dig returned malformed IP ($IP).  Cannot recover.  Bye."
+                     exit 1
+                  fi
+               done
+            fi
+         done <<< "$REMOTES"
+
+         printf '%s\n' \
+                '' '# allow traffic over the VPN interface' \
+                "add rule inet killswitch incoming iifname tun0 accept" \
+                "add rule inet killswitch outgoing oifname tun0 accept" >> $NFTABLES_CONFIG_FILE
+
+         nft -f $NFTABLES_CONFIG_FILE
+         ;;
+      *)
+         log_msg "info: kill switch is off"
+         for subnet in ${SUBNETS//,/ }; do
+            ip route add "$subnet" via "$DEFAULT_GATEWAY" dev "${TAP:-eth0}"
+         done
+         ;;
+   esac
+}
+
+####################### Main #######################
+log_msg "Container start"
 
 mkdir -p /data/{config,scripts,vpn}
 
-echo "
---- Running with the following variables ---"
+# Dump our devices as it may help the end-user determine if they need to
+# override our script's use of `eth0'
+log_msg "Devices"
+log_msg "======="
 
-if [[ $VPN_CONFIG_FILE ]]; then
-    echo "VPN configuration file: $VPN_CONFIG_FILE"
-fi
-if [[ $VPN_CONFIG_PATTERN ]]; then
-    echo "VPN configuration file name pattern: $VPN_CONFIG_PATTERN"
-fi
+ip --brief a | while read -r DEV ; do
+   log_msg "$DEV"
+done
+log_msg
 
-echo "Use default resolv.conf: ${USE_VPN_DNS:-off}
-Allowing subnets: ${SUBNETS:-none}
-Kill switch: $KILL_SWITCH
-Using OpenVPN log level: $VPN_LOG_LEVEL"
+dump_user_settings
 
-if is_enabled "$HTTP_PROXY"; then
-    echo "HTTP proxy: $HTTP_PROXY"
-    if is_enabled "$HTTP_PROXY_USERNAME"; then
-        echo "HTTP proxy username: $HTTP_PROXY_USERNAME"
-    elif is_enabled "$HTTP_PROXY_USERNAME_SECRET"; then
-        echo "HTTP proxy username secret: $HTTP_PROXY_USERNAME_SECRET"
-    fi
-fi
-if is_enabled "$SOCKS_PROXY"; then
-    echo "SOCKS proxy: $SOCKS_PROXY"
-    if [[ $SOCKS_LISTEN_ON ]]; then
-        echo "Listening on: $SOCKS_LISTEN_ON"
-    fi
-    if is_enabled "$SOCKS_PROXY_USERNAME"; then
-        echo "SOCKS proxy username: $SOCKS_PROXY_USERNAME"
-    elif is_enabled "$SOCKS_PROXY_USERNAME_SECRET"; then
-        echo "SOCKS proxy username secret: $SOCKS_PROXY_USERNAME_SECRET"
-    fi
-fi
+log_msg
 
-echo "---
-"
+gen_working_VPN_file
 
-if [[ $VPN_CONFIG_FILE ]]; then
-    original_config_file=vpn/$VPN_CONFIG_FILE
-elif [[ $VPN_CONFIG_PATTERN ]]; then
-    original_config_file=$(find vpn -name "$VPN_CONFIG_PATTERN" 2> /dev/null | sort | shuf -n 1)
-else
-    original_config_file=$(find vpn -name '*.conf' -o -name '*.ovpn' 2> /dev/null | sort | shuf -n 1)
-fi
-
-if [[ -z $original_config_file ]]; then
-    >&2 echo 'erro: no vpn configuration file found'
-    exit 1
-fi
-
-echo "info: original configuration file: $original_config_file"
-
-# Create a new configuration file to modify so the original is left untouched.
-modified_config_file=vpn/openvpn.$(tr -dc A-Za-z0-9 </dev/urandom | head -c8).conf
-trap cleanup SIGTERM
-
-echo "info: modified configuration file: $modified_config_file"
-grep -Ev '(^up\s|^down\s)' "$original_config_file" > "$modified_config_file"
-
-# Remove carriage returns (\r) from the config file
-sed -i 's/\r$//g' "$modified_config_file"
-
-
-default_gateway=$(ip -4 route | grep 'default via' | awk '{print $3}')
-
-case "$KILL_SWITCH" in
-    'iptables')
-        echo "info: kill switch is using iptables"
-
-        iptables -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
-        iptables -A INPUT -i lo -j ACCEPT
-        iptables -A OUTPUT -o lo -j ACCEPT
-
-        local_subnet=$(ip -4 route | grep 'scope link' | awk '{print $1}')
-        iptables -A INPUT -s "$local_subnet" -j ACCEPT
-        iptables -A OUTPUT -d "$local_subnet" -j ACCEPT
-
-        if [[ $SUBNETS ]]; then
-            for subnet in ${SUBNETS//,/ }; do
-                ip route add "$subnet" via "$default_gateway" dev eth0
-                iptables -A INPUT -s "$subnet" -j ACCEPT
-                iptables -A OUTPUT -d "$subnet" -j ACCEPT
-            done
-        fi
-
-        global_port=$(grep "^port " "$modified_config_file" | awk '{print $2}')
-        global_protocol=$(grep "^proto " "$modified_config_file" | awk '{print $2}')  # {$2 = substr($2, 1, 3)} 2
-        remotes=$(grep "^remote " "$modified_config_file" | awk '{print $2, $3, $4}')
-        ip_regex='^(([1-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))\.){3}([1-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))$'
-        while IFS= read -r line; do
-            IFS=' ' read -ra remote <<< "$line"
-            address=${remote[0]}
-            port=${remote[1]:-${global_port:-1194}}
-            protocol=${remote[2]:-${global_protocol:-udp}}
-
-            if [[ $address =~ $ip_regex ]]; then
-                iptables -A OUTPUT -o eth0 -d "$address" -p "$protocol" --dport "$port" -j ACCEPT
-            else
-                for ip in $(dig -4 +short "$address"); do
-                    iptables -A OUTPUT -o eth0 -d "$ip" -p "$protocol" --dport "$port" -j ACCEPT
-                    printf "%s %s\n" "$ip" "$address" >> /etc/hosts
-                done
-            fi
-        done <<< "$remotes"
-        iptables -A INPUT -i tun0 -j ACCEPT
-        iptables -A OUTPUT -o tun0 -j ACCEPT
-        iptables -P INPUT DROP
-        iptables -P OUTPUT DROP
-        iptables -P FORWARD DROP
-        iptables-save > config/iptables.conf
-        ;;
-
-    'nftables')
-        echo "info: kill switch is using nftables"
-        nftables_config_file=config/nftables.conf
-
-        printf '%s\n' \
-            '#!/usr/bin/nft' '' \
-            'flush ruleset' '' \
-            '# base ruleset' \
-            'add table inet killswitch' '' \
-            'add chain inet killswitch incoming { type filter hook input priority 0; policy drop; }' \
-            'add rule inet killswitch incoming ct state established,related accept' \
-            'add rule inet killswitch incoming iifname lo accept' '' \
-            'add chain inet killswitch outgoing { type filter hook output priority 0; policy drop; }' \
-            'add rule inet killswitch outgoing ct state established,related accept' \
-            'add rule inet killswitch outgoing oifname lo accept' '' > $nftables_config_file
-
-        local_subnet=$(ip -4 route | grep 'scope link' | awk '{print $1}')
-        printf '%s\n' \
-            '# allow traffic to/from the Docker subnet' \
-            "add rule inet killswitch incoming ip saddr $local_subnet accept" \
-            "add rule inet killswitch outgoing ip daddr $local_subnet accept" '' >> $nftables_config_file
-
-        if [[ $SUBNETS ]]; then
-            printf '# allow traffic to/from the specified subnets\n' >> $nftables_config_file
-            for subnet in ${SUBNETS//,/ }; do
-                ip route add "$subnet" via "$default_gateway" dev eth0
-                printf '%s\n' \
-                    "add rule inet killswitch incoming ip saddr $subnet accept" \
-                    "add rule inet killswitch outgoing ip daddr $subnet accept" '' >> $nftables_config_file
-            done
-        fi
-
-        global_port=$(grep "^port " "$modified_config_file" | awk '{print $2}')
-        global_protocol=$(grep "^proto " "$modified_config_file" | awk '{print $2}')  # {$2 = substr($2, 1, 3)} 2
-        remotes=$(grep "^remote " "$modified_config_file" | awk '{print $2, $3, $4}')
-
-        printf '# allow traffic to the VPN server(s)\n' >> $nftables_config_file
-        ip_regex='^(([1-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))\.){3}([1-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))$'
-        while IFS= read -r line; do
-            IFS=' ' read -ra remote <<< "$line"
-            address=${remote[0]}
-            port=${remote[1]:-${global_port:-1194}}
-            protocol=${remote[2]:-${global_protocol:-udp}}
-
-            if [[ $address =~ $ip_regex ]]; then
-                printf '%s\n' \
-                    "add rule inet killswitch outgoing oifname eth0 ip daddr $address $protocol dport $port accept" >> $nftables_config_file
-            else
-                for ip in $(dig -4 +short "$address"); do
-                    printf '%s\n' \
-                        "add rule inet killswitch outgoing oifname eth0 ip daddr $ip $protocol dport $port accept" >> $nftables_config_file
-                    printf "%s %s\n" "$ip" "$address" >> /etc/hosts
-                done
-            fi
-        done <<< "$remotes"
-
-        printf '%s\n' \
-            '' '# allow traffic over the VPN interface' \
-            "add rule inet killswitch incoming iifname tun0 accept" \
-            "add rule inet killswitch outgoing oifname tun0 accept" >> $nftables_config_file
-
-        nft -f $nftables_config_file
-        ;;
-
-    *)
-        echo "info: kill switch is off"
-        for subnet in ${SUBNETS//,/ }; do
-            ip route add "$subnet" via "$default_gateway" dev eth0
-        done
-        ;;
-
-esac
+setup_kill_switch
 
 if is_enabled "$HTTP_PROXY" ; then
-    scripts/run-http-proxy.sh &
+   log_msg "Backgrounding HTTP proxy ..."
+   scripts/run-http-proxy.sh &
 fi
 
 if is_enabled "$SOCKS_PROXY" ; then
-    scripts/run-socks-proxy.sh &
+   log_msg "Backgrounding SOCKS proxy ..."
+   scripts/run-socks-proxy.sh &
 fi
 
-openvpn_args=(
-    "--config" "$modified_config_file"
-    "--auth-nocache"
-    "--cd" "vpn"
-    "--pull-filter" "ignore" "ifconfig-ipv6 "
-    "--pull-filter" "ignore" "route-ipv6 "
-    "--script-security" "2"
-    "--up-restart"
-    "--verb" "$VPN_LOG_LEVEL"
+# Our trap handles gracefully terminating openvpn
+trap 'log_msg "Caught container exit signal"; cleanup; log_msg "Bye."; exit 0' SIGTERM
+
+log_msg "Backgrounding openvpn ..."
+OPENVPN_ARGS=(
+   "--config" "$MODIFIED_CONFIG_FILE"
+   "--auth-nocache"
+   "--cd" "vpn"
+   "--pull-filter" "ignore" "ifconfig-ipv6 "
+   "--pull-filter" "ignore" "route-ipv6 "
+   "--script-security" "2"
+   "--data-ciphers-fallback" "AES-256-CBC"
+   "--connect-retry" "${RETRY:-5}" "${MAX_RETRY:-60}"
+   "--server-poll-timeout" "${SERVER_POLL:-120}"
+   "--ping" "${PING:-15}"
+   "--ping-restart" "${PING_RESTART:-120}"
+   "--up-restart"
+   "--mute-replay-warnings"
+   "--comp-lzo" "no"
+   "--verb" "$VPN_LOG_LEVEL"
 )
 
+if is_enabled "$USE_FAST_IO" ; then
+   OPENVPN_ARGS+=(
+      "--fast-io"
+   )
+fi
+
+if [[ -n "$SNDBUF" ]] ; then
+   OPENVPN_ARGS+=(
+      "--sndbuf" "${SNDBUF}"
+   )
+fi
+
+if [[ -n "$RCVBUF" ]] ; then
+   OPENVPN_ARGS+=(
+      "--rcvbuf" "${RCVBUF}"
+   )
+fi
+
 if is_enabled "$USE_VPN_DNS" ; then
-    openvpn_args+=(
-        "--up" "/etc/openvpn/up.sh"
-        "--down" "/etc/openvpn/down.sh"
-    )
+   OPENVPN_ARGS+=(
+      "--up" "/etc/openvpn/up.sh"
+      "--down" "/etc/openvpn/down.sh"
+   )
 fi
 
 if [[ $VPN_AUTH_SECRET ]]; then
-    openvpn_args+=("--auth-user-pass" "/run/secrets/$VPN_AUTH_SECRET")
+   OPENVPN_ARGS+=("--auth-user-pass" "/run/secrets/$VPN_AUTH_SECRET")
 fi
 
-openvpn "${openvpn_args[@]}" &
-openvpn_child=$!
+openvpn "${OPENVPN_ARGS[@]}" &
+OPENVPN_CHILD=$!
 
-wait $openvpn_child
+wait $OPENVPN_CHILD
+
+# Never reached
+cleanup
+
+log_msg "Bye."
+exit 0

--- a/data/scripts/entry.sh
+++ b/data/scripts/entry.sh
@@ -56,12 +56,6 @@ dump_user_settings() {
    if is_enabled "$USE_FAST_IO" ; then
       log_msg "Fast IO enabled (--fast-io), a non-Windows, UDP-only switch"
    fi
-   if [[ -n "$SNDBUF" ]] ; then
-      log_msg "Send buffer (--sndbuf): ${SNDBUF}"
-   fi
-   if [[ -n "$RCVBUF" ]] ; then
-      log_msg "Receive buffer (--sndbuf): ${RCVBUF}"
-   fi
 
    if is_enabled "$HTTP_PROXY"; then
       log_msg "HTTP proxy: $HTTP_PROXY"
@@ -313,18 +307,6 @@ openvpn_args=(
 if is_enabled "$USE_FAST_IO" ; then
    openvpn_args+=(
       "--fast-io"
-   )
-fi
-
-if [[ -n "$SNDBUF" ]] ; then
-   openvpn_args+=(
-      "--sndbuf" "${SNDBUF}"
-   )
-fi
-
-if [[ -n "$RCVBUF" ]] ; then
-   openvpn_args+=(
-      "--rcvbuf" "${RCVBUF}"
    )
 fi
 

--- a/data/scripts/entry.sh
+++ b/data/scripts/entry.sh
@@ -46,6 +46,7 @@ dump_user_settings() {
    log_msg "Server poll timeout (--server-poll-timeout): ${SERVER_POLL:-120}"
    log_msg "Ping (--ping): ${PING:-15}"
    log_msg "Ping restart (--ping-restart): ${PING_RESTART:-120}"
+   log_msg "When kill switch enabled, dig timeout:  ${DIG_TIMEOUT:-5}"
    log_msg "Using OpenVPN log level: $VPN_LOG_LEVEL"
    if [[ -n "$TAP" ]] ; then
       log_msg "Container script 'eth0' remapped to '${TAP}'"

--- a/data/scripts/entry.sh
+++ b/data/scripts/entry.sh
@@ -2,24 +2,24 @@
 
 set -e
 
-BASENAME=$(basename "$0")
+basename=$(basename "$0")
 log_msg() {
-   echo -e "$(date +'%F %T')" ["$BASENAME"] "$@"
+   echo -e "$(date +'%F %T')" ["$basename"] "$@"
 }
 
 cleanup() {
-   if [[ -n "$OPENVPN_CHILD" ]]; then
+   if [[ -n "$openvpn_child" ]]; then
       log_msg "Asking openvpn to exit gracefully"
-      kill SIGTERM $OPENVPN_CHILD > /dev/null 2>&1
-      I=15
-      while [[ $I -ge 0 ]] ; do
-         kill -0 $OPENVPN_CHILD > /dev/null 2>&1
+      kill SIGTERM $openvpn_child > /dev/null 2>&1
+      i=15
+      while [[ $i -ge 0 ]] ; do
+         kill -0 $openvpn_child > /dev/null 2>&1
          if [[ $? -eq 1 ]] ; then
             break
          fi
-         log_msg "Waiting on openvpn to end ... $I"
+         log_msg "Waiting on openvpn to end ... $i"
          sleep 1
-         ((I--))
+         ((i--))
       done
    fi
 }
@@ -46,7 +46,7 @@ dump_user_settings() {
    log_msg "Server poll timeout (--server-poll-timeout): ${SERVER_POLL:-120}"
    log_msg "Ping (--ping): ${PING:-15}"
    log_msg "Ping restart (--ping-restart): ${PING_RESTART:-120}"
-   log_msg "When kill switch enabled, dig timeout:  ${DIG_TIMEOUT:-5}"
+   log_msg "When kill switch enabled, dig timeout: ${DIG_TIMEOUT:-5}"
    log_msg "Using OpenVPN log level: $VPN_LOG_LEVEL"
    if [[ -n "$TAP" ]] ; then
       log_msg "Container script 'eth0' remapped to '${TAP}'"
@@ -90,40 +90,40 @@ dump_user_settings() {
 
 gen_working_VPN_file() {
    if [[ $VPN_CONFIG_FILE ]]; then
-      ORIGINAL_CONFIG_FILE=vpn/$VPN_CONFIG_FILE
+      original_config_file=vpn/$VPN_CONFIG_FILE
    elif [[ $VPN_CONFIG_PATTERN ]]; then
-      ORIGINAL_CONFIG_FILE=$(find vpn -name "$VPN_CONFIG_PATTERN" 2> /dev/null | sort | shuf -n 1)
+      original_config_file=$(find vpn -name "$VPN_CONFIG_PATTERN" 2> /dev/null | sort | shuf -n 1)
    else
-      ORIGINAL_CONFIG_FILE=$(find vpn -name '*.conf' -o -name '*.ovpn' 2> /dev/null | sort | shuf -n 1)
+      original_config_file=$(find vpn -name '*.conf' -o -name '*.ovpn' 2> /dev/null | sort | shuf -n 1)
    fi
 
-   if [[ ! -f $ORIGINAL_CONFIG_FILE ]]; then
-      >&2 log_msg "erro: no vpn configuration file found"
+   if [[ ! -s $original_config_file ]]; then
+      >&2 log_msg "erro: no vpn configuration file found or zero-sized"
       exit 1
    fi
 
-   log_msg "info: original configuration file: $ORIGINAL_CONFIG_FILE"
+   log_msg "info: original configuration file: $original_config_file"
 
    # Create a new configuration file to modify so the original is left
    # untouched.
    #
    # Use the passed in $DEBUG_VPN_CONFIG_FILE variable to determine whether
    # the modified file is ephemeral or not.
-   MOD_DIR="/tmp"
+   mod_dir="/tmp"
    if is_enabled "$DEBUG_VPN_CONFIG_FILE" ; then
-      MOD_DIR="vpn"
+      mod_dir="vpn"
    fi
-   MODIFIED_CONFIG_FILE=$MOD_DIR/openvpn.$(tr -dc A-Za-z0-9 </dev/urandom | head -c8).conf
+   modified_config_file=$mod_dir/openvpn.$(tr -dc A-Za-z0-9 </dev/urandom | head -c8).conf
 
-   log_msg "info: modified configuration file: $MODIFIED_CONFIG_FILE"
-   grep -Ev '(^up\s|^down\s)' "$ORIGINAL_CONFIG_FILE" > "$MODIFIED_CONFIG_FILE"
+   log_msg "info: modified configuration file: $modified_config_file"
+   grep -Ev '(^up\s|^down\s)' "$original_config_file" > "$modified_config_file"
 
    # Remove carriage returns (\r) from the config file
-   sed -i 's/\r$//g' "$MODIFIED_CONFIG_FILE"
+   sed -i 's/\r$//g' "$modified_config_file"
 }
 
 setup_kill_switch() {
-   DEFAULT_GATEWAY=$(ip -4 route | grep 'default via' | awk '{print $3}')
+   default_gateway=$(ip -4 route | grep 'default via' | awk '{print $3}')
    case "$KILL_SWITCH" in
       'iptables')
          log_msg "Configuring $KILL_SWITCH kill switch"
@@ -132,43 +132,43 @@ setup_kill_switch() {
          iptables -A INPUT -i lo -j ACCEPT
          iptables -A OUTPUT -o lo -j ACCEPT
 
-         LOCAL_SUBNET=$(ip -4 route | grep 'scope link' | awk '{print $1}')
-         iptables -A INPUT -s "$LOCAL_SUBNET" -j ACCEPT
-         iptables -A OUTPUT -d "$LOCAL_SUBNET" -j ACCEPT
+         local_subnet=$(ip -4 route | grep 'scope link' | awk '{print $1}')
+         iptables -A INPUT -s "$local_subnet" -j ACCEPT
+         iptables -A OUTPUT -d "$local_subnet" -j ACCEPT
 
          if [[ $SUBNETS ]]; then
-            for SUBNET in ${SUBNETS//,/ }; do
-               ip route add "$SUBNET" via "$DEFAULT_GATEWAY" dev "${TAP:-eth0}"
-               iptables -A INPUT -s "$SUBNET" -j ACCEPT
-               iptables -A OUTPUT -d "$SUBNET" -j ACCEPT
+            for subnet in ${SUBNETS//,/ }; do
+               ip route add "$subnet" via "$default_gateway" dev "${TAP:-eth0}"
+               iptables -A INPUT -s "$subnet" -j ACCEPT
+               iptables -A OUTPUT -d "$subnet" -j ACCEPT
             done
          fi
 
-         GLOBAL_PORT=$(grep "^port " "$MODIFIED_CONFIG_FILE" | awk '{print $2}')
-         GLOBAL_PROTOCOL=$(grep "^proto " "$MODIFIED_CONFIG_FILE" | awk '{print $2}')  # {$2 = substr($2, 1, 3)} 2
-         REMOTES=$(grep "^remote " "$MODIFIED_CONFIG_FILE" | awk '{print $2, $3, $4}')
-         IP_REGEX='^(([1-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))\.){3}([1-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))$'
-         while IFS= read -r LINE; do
-            IFS=' ' read -ra REMOTE <<< "$LINE"
-            ADDRESS=${REMOTE[0]}
-            PORT=${REMOTE[1]:-${GLOBAL_PORT:-1194}}
-            PROTOCOL=${REMOTE[2]:-${GLOBAL_PROTOCOL:-udp}}
+         global_port=$(grep "^port " "$modified_config_file" | awk '{print $2}')
+         global_protocol=$(grep "^proto " "$modified_config_file" | awk '{print $2}')  # {$2 = substr($2, 1, 3)} 2
+         remotes=$(grep "^remote " "$modified_config_file" | awk '{print $2, $3, $4}')
+         ip_regex='^(([1-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))\.){3}([1-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))$'
+         while IFS= read -r line; do
+            IFS=' ' read -ra remote <<< "$line"
+            address=${remote[0]}
+            port=${remote[1]:-${global_port:-1194}}
+            protocol=${remote[2]:-${global_protocol:-udp}}
 
-            if [[ $ADDRESS =~ $IP_REGEX ]]; then
-               iptables -A OUTPUT -o "${TAP:-eth0}" -d "$ADDRESS" -p "$PROTOCOL" --dport "$PORT" -j ACCEPT
+            if [[ $address =~ $ip_regex ]]; then
+               iptables -A OUTPUT -o "${TAP:-eth0}" -d "$address" -p "$protocol" --dport "$port" -j ACCEPT
             else
-               log_msg "dig lookup on $ADDRESS"
-               for IP in $(dig -4 +timeout="${DIG_TIMEOUT:-5}" +tries=1 +short "$ADDRESS"); do
-                  if echo "$IP" | grep -s '^[0-9]' > /dev/null 2>&1 ; then
-                     iptables -A OUTPUT -o "${TAP:-eth0}" -d "$IP" -p "$PROTOCOL" --dport "$PORT" -j ACCEPT
-                     printf "%s %s\n" "$IP" "$ADDRESS" >> /etc/hosts
+               log_msg "dig lookup on $address"
+               for ip in $(dig -4 +timeout="${DIG_TIMEOUT:-5}" +tries=1 +short "$address"); do
+                  if echo "$ip" | grep -s '^[0-9]' > /dev/null 2>&1 ; then
+                     iptables -A OUTPUT -o "${TAP:-eth0}" -d "$ip" -p "$protocol" --dport "$port" -j ACCEPT
+                     printf "%s %s\n" "$ip" "$address" >> /etc/hosts
                   else
                      log_msg "dig returned malformed IP ($IP).  Cannot recover. Bye."
                      exit 1
                   fi
                done
             fi
-         done <<< "$REMOTES"
+         done <<< "$remotes"
          iptables -A INPUT -i tun0 -j ACCEPT
          iptables -A OUTPUT -o tun0 -j ACCEPT
          iptables -P INPUT DROP
@@ -179,7 +179,7 @@ setup_kill_switch() {
       'nftables')
          log_msg "Configuring $KILL_SWITCH kill switch"
 
-         NFTABLES_CONFIG_FILE=config/nftables.conf
+         nftables_config_file=config/nftables.conf
 
          printf '%s\n' \
                 '#!/usr/bin/nft' '' \
@@ -191,65 +191,65 @@ setup_kill_switch() {
                 'add rule inet killswitch incoming iifname lo accept' '' \
                 'add chain inet killswitch outgoing { type filter hook output priority 0; policy drop; }' \
                 'add rule inet killswitch outgoing ct state established,related accept' \
-                'add rule inet killswitch outgoing oifname lo accept' '' > $NFTABLES_CONFIG_FILE
+                'add rule inet killswitch outgoing oifname lo accept' '' > $nftables_config_file
 
-         LOCAL_SUBNET=$(ip -4 route | grep 'scope link' | awk '{print $1}')
+         local_subnet=$(ip -4 route | grep 'scope link' | awk '{print $1}')
          printf '%s\n' \
                 '# allow traffic to/from the Docker subnet' \
-                "add rule inet killswitch incoming ip saddr $LOCAL_SUBNET accept" \
-                "add rule inet killswitch outgoing ip daddr $LOCAL_SUBNET accept" '' >> $NFTABLES_CONFIG_FILE
+                "add rule inet killswitch incoming ip saddr $local_subnet accept" \
+                "add rule inet killswitch outgoing ip daddr $local_subnet accept" '' >> $nftables_config_file
 
          if [[ $SUBNETS ]]; then
-            printf '# allow traffic to/from the specified subnets\n' >> $NFTABLES_CONFIG_FILE
+            printf '# allow traffic to/from the specified subnets\n' >> $nftables_config_file
             for subnet in ${SUBNETS//,/ }; do
-               ip route add "$subnet" via "$DEFAULT_GATEWAY" dev "${TAP:-eth0}"
+               ip route add "$subnet" via "$default_gateway" dev "${TAP:-eth0}"
                printf '%s\n' \
                       "add rule inet killswitch incoming ip saddr $subnet accept" \
-                      "add rule inet killswitch outgoing ip daddr $subnet accept" '' >> $NFTABLES_CONFIG_FILE
+                      "add rule inet killswitch outgoing ip daddr $subnet accept" '' >> $nftables_config_file
             done
          fi
 
-         GLOBAL_PORT=$(grep "^port " "$MODIFIED_CONFIG_FILE" | awk '{print $2}')
-         GLOBAL_PROTOCOL=$(grep "^proto " "$MODIFIED_CONFIG_FILE" | awk '{print $2}')  # {$2 = substr($2, 1, 3)} 2
-         REMOTES=$(grep "^remote " "$MODIFIED_CONFIG_FILE" | awk '{print $2, $3, $4}')
+         global_port=$(grep "^port " "$modified_config_file" | awk '{print $2}')
+         global_protocol=$(grep "^proto " "$modified_config_file" | awk '{print $2}')  # {$2 = substr($2, 1, 3)} 2
+         remotes=$(grep "^remote " "$modified_config_file" | awk '{print $2, $3, $4}')
 
-         printf '# allow traffic to the VPN server(s)\n' >> $NFTABLES_CONFIG_FILE
-         IP_REGEX='^(([1-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))\.){3}([1-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))$'
-         while IFS= read -r LINE; do
-            IFS=' ' read -ra REMOTE <<< "$LINE"
-            ADDRESS=${REMOTE[0]}
-            PORT=${REMOTE[1]:-${GLOBAL_PORT:-1194}}
-            PROTOCOL=${REMOTE[2]:-${GLOBAL_PROTOCOL:-udp}}
+         printf '# allow traffic to the VPN server(s)\n' >> $nftables_config_file
+         ip_regex='^(([1-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))\.){3}([1-9]?[0-9]|1[0-9][0-9]|2([0-4][0-9]|5[0-5]))$'
+         while IFS= read -r line; do
+            IFS=' ' read -ra remote <<< "$line"
+            address=${remote[0]}
+            port=${remote[1]:-${global_port:-1194}}
+            protocol=${remote[2]:-${global_protocol:-udp}}
 
-            if [[ $ADDRESS =~ $IP_REGEX ]]; then
+            if [[ $address =~ $ip_regex ]]; then
                printf '%s\n' \
-                      "add rule inet killswitch outgoing oifname ${TAP:-eth0} ip daddr $ADDRESS $PROTOCOL dport $PORT accept" >> $NFTABLES_CONFIG_FILE
+                      "add rule inet killswitch outgoing oifname ${TAP:-eth0} ip daddr $address $protocol dport $port accept" >> $nftables_config_file
             else
-               log_msg "dig lookup on $ADDRESS"
-               for IP in $(dig -4 +timeout="${DIG_TIMEOUT:-5}" +tries=1 +short "$ADDRESS"); do
-                  if echo "$IP" | grep -s '^[0-9]' > /dev/null 2>&1 ; then
+               log_msg "dig lookup on $address"
+               for ip in $(dig -4 +timeout="${DIG_TIMEOUT:-5}" +tries=1 +short "$address"); do
+                  if echo "$ip" | grep -s '^[0-9]' > /dev/null 2>&1 ; then
                      printf '%s\n' \
-                            "add rule inet killswitch outgoing oifname ${TAP:-eth0} ip daddr $IP $PROTOCOL dport $PORT accept" >> $NFTABLES_CONFIG_FILE
-                     printf "%s %s\n" "$IP" "$ADDRESS" >> /etc/hosts
+                            "add rule inet killswitch outgoing oifname ${TAP:-eth0} ip daddr $ip $protocol dport $port accept" >> $nftables_config_file
+                     printf "%s %s\n" "$ip" "$address" >> /etc/hosts
                   else
-                     log_msg "dig returned malformed IP ($IP).  Cannot recover.  Bye."
+                     log_msg "dig returned malformed IP ($ip).  Cannot recover.  Bye."
                      exit 1
                   fi
                done
             fi
-         done <<< "$REMOTES"
+         done <<< "$remotes"
 
          printf '%s\n' \
                 '' '# allow traffic over the VPN interface' \
                 "add rule inet killswitch incoming iifname tun0 accept" \
-                "add rule inet killswitch outgoing oifname tun0 accept" >> $NFTABLES_CONFIG_FILE
+                "add rule inet killswitch outgoing oifname tun0 accept" >> $nftables_config_file
 
-         nft -f $NFTABLES_CONFIG_FILE
+         nft -f $nftables_config_file
          ;;
       *)
          log_msg "info: kill switch is off"
          for subnet in ${SUBNETS//,/ }; do
-            ip route add "$subnet" via "$DEFAULT_GATEWAY" dev "${TAP:-eth0}"
+            ip route add "$subnet" via "$default_gateway" dev "${TAP:-eth0}"
          done
          ;;
    esac
@@ -265,8 +265,8 @@ mkdir -p /data/{config,scripts,vpn}
 log_msg "Devices"
 log_msg "======="
 
-ip --brief a | while read -r DEV ; do
-   log_msg "$DEV"
+ip --brief a | while read -r dev ; do
+   log_msg "$dev"
 done
 log_msg
 
@@ -292,8 +292,8 @@ fi
 trap 'log_msg "Caught container exit signal"; cleanup; log_msg "Bye."; exit 0' SIGTERM
 
 log_msg "Backgrounding openvpn ..."
-OPENVPN_ARGS=(
-   "--config" "$MODIFIED_CONFIG_FILE"
+openvpn_args=(
+   "--config" "$modified_config_file"
    "--auth-nocache"
    "--cd" "vpn"
    "--pull-filter" "ignore" "ifconfig-ipv6 "
@@ -311,38 +311,38 @@ OPENVPN_ARGS=(
 )
 
 if is_enabled "$USE_FAST_IO" ; then
-   OPENVPN_ARGS+=(
+   openvpn_args+=(
       "--fast-io"
    )
 fi
 
 if [[ -n "$SNDBUF" ]] ; then
-   OPENVPN_ARGS+=(
+   openvpn_args+=(
       "--sndbuf" "${SNDBUF}"
    )
 fi
 
 if [[ -n "$RCVBUF" ]] ; then
-   OPENVPN_ARGS+=(
+   openvpn_args+=(
       "--rcvbuf" "${RCVBUF}"
    )
 fi
 
 if is_enabled "$USE_VPN_DNS" ; then
-   OPENVPN_ARGS+=(
+   openvpn_args+=(
       "--up" "/etc/openvpn/up.sh"
       "--down" "/etc/openvpn/down.sh"
    )
 fi
 
 if [[ $VPN_AUTH_SECRET ]]; then
-   OPENVPN_ARGS+=("--auth-user-pass" "/run/secrets/$VPN_AUTH_SECRET")
+   openvpn_args+=("--auth-user-pass" "/run/secrets/$VPN_AUTH_SECRET")
 fi
 
-openvpn "${OPENVPN_ARGS[@]}" &
-OPENVPN_CHILD=$!
+openvpn "${openvpn_args[@]}" &
+openvpn_child=$!
 
-wait $OPENVPN_CHILD
+wait $openvpn_child
 
 # Never reached
 cleanup

--- a/data/scripts/run-http-proxy.sh
+++ b/data/scripts/run-http-proxy.sh
@@ -2,9 +2,9 @@
 
 set -e
 
-BASENAME=$(basename "$0")
+basename=$(basename "$0")
 log_msg() {
-   echo -e "$(date +'%F %T')" ["$BASENAME"] "$@"
+   echo -e "$(date +'%F %T')" ["$basename"] "$@"
 }
 
 log_msg "Waiting for tun0 to become available ..."
@@ -13,28 +13,28 @@ until ip link show tun0 2>&1 | grep -qv "does not exist"; do
 done
 log_msg "tun0 ready."
 
-PROXY_CONFIG_FILE=config/http-proxy.conf
+proxy_config_file=config/http-proxy.conf
 
-ADDR_ETH0=$(ip address show "${TAP:-eth0}" | grep 'inet ' | awk '{split($2, inet, "/"); print inet[1]}')
-ADDR_TUN0=$(ip address show tun0 | grep 'inet ' | awk '{split($2, inet, "/"); print inet[1]}')
+addr_eth0=$(ip address show "${TAP:-eth0}" | grep 'inet ' | awk '{split($2, inet, "/"); print inet[1]}')
+addr_tun0=$(ip address show tun0 | grep 'inet ' | awk '{split($2, inet, "/"); print inet[1]}')
 sed -i \
-    -e "/Listen/c Listen $ADDR_ETH0" \
-    -e "/Bind/c Bind $ADDR_TUN0" \
-    $PROXY_CONFIG_FILE
+    -e "/Listen/c Listen $addr_eth0" \
+    -e "/Bind/c Bind $addr_tun0" \
+    $proxy_config_file
 
 if [[ $HTTP_PROXY_USERNAME && $HTTP_PROXY_PASSWORD ]]; then
     log_msg 'info: starting http proxy with credentials'
-    printf 'BasicAuth %s %s\n' "$HTTP_PROXY_USERNAME" "$HTTP_PROXY_PASSWORD" >> $PROXY_CONFIG_FILE
+    printf 'BasicAuth %s %s\n' "$HTTP_PROXY_USERNAME" "$HTTP_PROXY_PASSWORD" >> $proxy_config_file
 elif [[ -f "/run/secrets/$HTTP_PROXY_USERNAME_SECRET" && -f "/run/secrets/$HTTP_PROXY_PASSWORD_SECRET" ]]; then
     log_msg 'info: starting http proxy with credentials'
     printf 'BasicAuth %s %s\n' \
         "$(cat /run/secrets/"$HTTP_PROXY_USERNAME_SECRET")" \
-        "$(cat /run/secrets/"$HTTP_PROXY_PASSWORD_SECRET")" >> $PROXY_CONFIG_FILE
+        "$(cat /run/secrets/"$HTTP_PROXY_PASSWORD_SECRET")" >> $proxy_config_file
 else
     log_msg 'info: starting http proxy without credentials'
 fi
 
-exec tinyproxy -d -c $PROXY_CONFIG_FILE
+exec tinyproxy -d -c $proxy_config_file
 
 # Never executed
 exit $?

--- a/data/scripts/run-http-proxy.sh
+++ b/data/scripts/run-http-proxy.sh
@@ -2,29 +2,39 @@
 
 set -e
 
+BASENAME=$(basename "$0")
+log_msg() {
+   echo -e "$(date +'%F %T')" ["$BASENAME"] "$@"
+}
+
+log_msg "Waiting for tun0 to become available ..."
 until ip link show tun0 2>&1 | grep -qv "does not exist"; do
-    sleep 1
+    sleep 0.5
 done
+log_msg "tun0 ready."
 
-proxy_config_file=config/http-proxy.conf
+PROXY_CONFIG_FILE=config/http-proxy.conf
 
-addr_eth0=$(ip address show eth0 | grep 'inet ' | awk '{split($2, inet, "/"); print inet[1]}')
-addr_tun0=$(ip address show tun0 | grep 'inet ' | awk '{split($2, inet, "/"); print inet[1]}')
+ADDR_ETH0=$(ip address show "${TAP:-eth0}" | grep 'inet ' | awk '{split($2, inet, "/"); print inet[1]}')
+ADDR_TUN0=$(ip address show tun0 | grep 'inet ' | awk '{split($2, inet, "/"); print inet[1]}')
 sed -i \
-    -e "/Listen/c Listen $addr_eth0" \
-    -e "/Bind/c Bind $addr_tun0" \
-    $proxy_config_file
+    -e "/Listen/c Listen $ADDR_ETH0" \
+    -e "/Bind/c Bind $ADDR_TUN0" \
+    $PROXY_CONFIG_FILE
 
 if [[ $HTTP_PROXY_USERNAME && $HTTP_PROXY_PASSWORD ]]; then
-    echo 'info: starting http proxy with credentials'
-    printf 'BasicAuth %s %s\n' "$HTTP_PROXY_USERNAME" "$HTTP_PROXY_PASSWORD" >> $proxy_config_file
+    log_msg 'info: starting http proxy with credentials'
+    printf 'BasicAuth %s %s\n' "$HTTP_PROXY_USERNAME" "$HTTP_PROXY_PASSWORD" >> $PROXY_CONFIG_FILE
 elif [[ -f "/run/secrets/$HTTP_PROXY_USERNAME_SECRET" && -f "/run/secrets/$HTTP_PROXY_PASSWORD_SECRET" ]]; then
-    echo 'info: starting http proxy with credentials'
+    log_msg 'info: starting http proxy with credentials'
     printf 'BasicAuth %s %s\n' \
         "$(cat /run/secrets/"$HTTP_PROXY_USERNAME_SECRET")" \
-        "$(cat /run/secrets/"$HTTP_PROXY_PASSWORD_SECRET")" >> $proxy_config_file
+        "$(cat /run/secrets/"$HTTP_PROXY_PASSWORD_SECRET")" >> $PROXY_CONFIG_FILE
 else
-    echo 'info: starting http proxy without credentials'
+    log_msg 'info: starting http proxy without credentials'
 fi
 
-exec tinyproxy -d -c $proxy_config_file
+exec tinyproxy -d -c $PROXY_CONFIG_FILE
+
+# Never executed
+exit $?

--- a/data/scripts/run-socks-proxy.sh
+++ b/data/scripts/run-socks-proxy.sh
@@ -2,25 +2,35 @@
 
 set -e
 
-until ip link show tun0 2>&1 | grep -qv "does not exist"; do
-    sleep 1
-done
+BASENAME=$(basename "$0")
+log_msg() {
+   echo -e "$(date +'%F %T')" ["$BASENAME"] "$@"
+}
 
-proxy_config_file=config/socks-proxy.conf
+log_msg "Waiting for tun0 to become available ..."
+until ip link show tun0 2>&1 | grep -qv "does not exist"; do
+    sleep 0.5
+done
+log_msg "tun0 ready."
+
+PROXY_CONFIG_FILE=config/socks-proxy.conf
 
 if [[ $SOCKS_LISTEN_ON ]]; then
-    sed -i "/internal: /c internal: $SOCKS_LISTEN_ON port = 1080" $proxy_config_file
+    sed -i "/internal: /c internal: $SOCKS_LISTEN_ON port = 1080" $PROXY_CONFIG_FILE
 fi
 if [[ $SOCKS_PROXY_USERNAME && $SOCKS_PROXY_PASSWORD ]]; then
-    printf 'info: starting socks proxy with credentials\n'
-    id "$SOCKS_PROXY_USERNAME" &> /dev/null || useradd "$SOCKS_PROXY_USERNAME" -s /bin/false -M -p "$(mkpasswd "$SOCKS_PROXY_PASSWORD")"
-    sed -i "/method: /c method: username" $proxy_config_file
+    log_msg 'info: starting socks proxy with credentials'
+    useradd "$SOCKS_PROXY_USERNAME" -s /bin/false -M -p "$(mkpasswd "$SOCKS_PROXY_PASSWORD")"
+    sed -i "/method: /c method: username" $PROXY_CONFIG_FILE
 elif [[ -f "/run/secrets/$SOCKS_PROXY_USERNAME_SECRET" && -f "/run/secrets/$SOCKS_PROXY_PASSWORD_SECRET" ]]; then
-    printf 'info: starting socks proxy with credentials\n'
-    id "$(cat /run/secrets/"$SOCKS_PROXY_USERNAME_SECRET")" &> /dev/null || useradd "$(cat /run/secrets/"$SOCKS_PROXY_USERNAME_SECRET")" -s /bin/false -M -p "$(mkpasswd "$(cat /run/secrets/"$SOCKS_PROXY_PASSWORD_SECRET")")"
-    sed -i "/method: /c method: username" $proxy_config_file
+    log_msg 'info: starting socks proxy with credentials'
+    useradd "$(cat /run/secrets/"$SOCKS_PROXY_USERNAME_SECRET")" -s /bin/false -M -p "$(mkpasswd "$(cat /run/secrets/"$SOCKS_PROXY_PASSWORD_SECRET")")"
+    sed -i "/method: /c method: username" $PROXY_CONFIG_FILE
 else
-    printf 'info: starting socks proxy without credentials\n'
+    log_msg 'info: starting socks proxy without credentials'
 fi
 
-exec sockd -f $proxy_config_file
+exec sockd -f $PROXY_CONFIG_FILE
+
+# Never executed
+exit $?

--- a/data/scripts/run-socks-proxy.sh
+++ b/data/scripts/run-socks-proxy.sh
@@ -2,9 +2,9 @@
 
 set -e
 
-BASENAME=$(basename "$0")
+basename=$(basename "$0")
 log_msg() {
-   echo -e "$(date +'%F %T')" ["$BASENAME"] "$@"
+   echo -e "$(date +'%F %T')" ["$basename"] "$@"
 }
 
 log_msg "Waiting for tun0 to become available ..."
@@ -13,24 +13,24 @@ until ip link show tun0 2>&1 | grep -qv "does not exist"; do
 done
 log_msg "tun0 ready."
 
-PROXY_CONFIG_FILE=config/socks-proxy.conf
+proxy_config_file=config/socks-proxy.conf
 
 if [[ $SOCKS_LISTEN_ON ]]; then
-    sed -i "/internal: /c internal: $SOCKS_LISTEN_ON port = 1080" $PROXY_CONFIG_FILE
+    sed -i "/internal: /c internal: $SOCKS_LISTEN_ON port = 1080" $proxy_config_file
 fi
 if [[ $SOCKS_PROXY_USERNAME && $SOCKS_PROXY_PASSWORD ]]; then
     log_msg 'info: starting socks proxy with credentials'
     useradd "$SOCKS_PROXY_USERNAME" -s /bin/false -M -p "$(mkpasswd "$SOCKS_PROXY_PASSWORD")"
-    sed -i "/method: /c method: username" $PROXY_CONFIG_FILE
+    sed -i "/method: /c method: username" $proxy_config_file
 elif [[ -f "/run/secrets/$SOCKS_PROXY_USERNAME_SECRET" && -f "/run/secrets/$SOCKS_PROXY_PASSWORD_SECRET" ]]; then
     log_msg 'info: starting socks proxy with credentials'
     useradd "$(cat /run/secrets/"$SOCKS_PROXY_USERNAME_SECRET")" -s /bin/false -M -p "$(mkpasswd "$(cat /run/secrets/"$SOCKS_PROXY_PASSWORD_SECRET")")"
-    sed -i "/method: /c method: username" $PROXY_CONFIG_FILE
+    sed -i "/method: /c method: username" $proxy_config_file
 else
     log_msg 'info: starting socks proxy without credentials'
 fi
 
-exec sockd -f $PROXY_CONFIG_FILE
+exec sockd -f $proxy_config_file
 
 # Never executed
 exit $?


### PR DESCRIPTION
Hi,

_In retrospect, I think I should have created a smaller PR to avoid this monolithic PR.  I'm terribly sorry about it.  If need be, please reject it and I'll resubmit it piecemeal.  I'll use it as a learning experience.  :)_

This PR addresses the following issues:  #97, #94 and #93.

Additionally, I fixed an edge-case when the `Kill Switch` is enabled and there is no Internet:  not checking for a bad value from `dig`.  If this happens. we `exit 1` from the script and we restart.  I also set `dig`'s `+tries=1` (default is 3.  This way we can fail straight away.  Further, I exposed `DIG_TIMEOUT` for users to tune.

I created a log_msg() function in each of the core scripts to standardize the output:  `YYYY-MM-DD 24H:MI:SS [scriptname]` .  I replaced the `echo`s accordingly and added more calls to `log_msg()`.  I sprinkled a bit more instrumentation in the scripts to aid with possible user issues.

I've tried to make the output a bit more user-friendly by listing the user parameters at the top in a section.  For end-user debugging purposes (`podman` users), I'm listing the devices the container knows about.  For example, with `podman`, the tapped device is `tun0`.  The script uses `eth0` as that is what `docker` presents.  `eth0` can be overridden by the user.

I hope it's not too controversial but I made all lowercase shell variables uppercase.  The script had a mix.  Possibly even more controversial, moved big chunks of  code in `entry.sh` into functions.  The idea is to make the main body more readable and thus, easier to maintain.

I exposed some performance tunables as well as tuneables to reduce the VPN availability lag on an internet hiccup.

On termination, I noticed that the child `openvpn` was not given adequate time to clean up (`sleep 0.5`).  I've implemented a simple check with fail-safe to allow for a graceful termination (and tear down).