### PR TITLE
Fixes killswitch.sh not being executed due to script security

### DIFF
--- a/build/entry.sh
+++ b/build/entry.sh
@@ -34,6 +34,7 @@ openvpn_args=(
 )
 
 if is_enabled "$KILL_SWITCH"; then
+    openvpn_args+=("--script-security" "2")
     openvpn_args+=("--route-up" "/usr/local/bin/killswitch.sh $ALLOWED_SUBNETS")
 fi
 


### PR DESCRIPTION
I was not able to connect from my local network to the open port from one of the docker containers, and while debugging I noticed that the reason was that killswitch.sh was not being executed after openvpn is up (and thus the iptables was not being set correctly).

Checking the openvpn logs I found this:
```
2023-06-06 14:01:18 WARNING: External program may not be called unless '--script-security 2' or higher is enabled. See --help text or man page for detailed info.
2023-06-06 14:01:18 WARNING: Failed running command (--route-up): disallowed by script-security setting
2023-06-06 14:01:18 Initialization Sequence Completed
```

So basically, if killswitch is set, I add `--script-security 2`.