### PR TITLE
adding ability to run with authfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ services:
 | --- | --- | --- |
 | `ALLOWED_SUBNETS` | | A list of one or more comma-separated subnets (e.g. `192.168.0.0/24,192.168.1.0/24`) to allow outside of the VPN tunnel. |
 | `AUTH_SECRET` | | Docker secret that contains the credentials for accessing the VPN. |
+| `AUTH_SECRET_FILE` | | file path that contains the credentials for accessing the VPN. |
 | `CONFIG_FILE` | | The OpenVPN configuration file or search pattern. If unset, a random `.conf` or `.ovpn` file will be selected. |
 | `KILL_SWITCH` | `on` | Whether or not to enable the kill switch. Set to any "truthy" value[1] to enable. |
 

--- a/build/entry.sh
+++ b/build/entry.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 set -o errexit
-set -o nounset
 set -o pipefail
 
 cleanup() {
@@ -30,7 +29,7 @@ echo "using openvpn configuration file: $config_file"
 
 openvpn_args=(
     "--config" "$config_file"
-    "--cd" "/config"
+    "--cd" "/"
 )
 
 if is_enabled "$KILL_SWITCH"; then
@@ -40,6 +39,10 @@ fi
 # Docker secret that contains the credentials for accessing the VPN.
 if [[ $AUTH_SECRET ]]; then
     openvpn_args+=("--auth-user-pass" "/run/secrets/$AUTH_SECRET")
+elif [[ $AUTH_SECRET_FILE ]]; then
+
+openvpn_args+=("--auth-user-pass" "$AUTH_SECRET_FILE")
+
 fi
 
 openvpn "${openvpn_args[@]}" &


### PR DESCRIPTION
fixing 
`sudo docker run --rm  -it -e ALLOWED_SUBNETS="" -e CONFIG_FILE="" --name=openvpn-client --cap-add=NET_ADMIN --device=/dev/net/tun --volume="/home/ubuntu/vpn_new:/config" dockeropenvpnclient:latest
using openvpn configuration file: ****
/usr/local/bin/entry.sh: line 41: AUTH_SECRET: unbound variable`


and added ability to use authfile