### PR TITLE
fix: unbind variables

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17
+FROM alpine:3.19
 
 RUN apk add --no-cache \
     bash \

--- a/build/entry.sh
+++ b/build/entry.sh
@@ -13,6 +13,11 @@ is_enabled() {
     [[ ${1,,} =~ ^(true|t|yes|y|1|on|enable|enabled)$ ]]
 }
 
+CONFIG_FILE=${CONFIG_FILE:=}
+KILL_SWITCH=${KILL_SWITCH:=on}
+ALLOWED_SUBNETS=${ALLOWED_SUBNETS:=}
+AUTH_SECRET=${AUTH_SECRET:=}
+
 # Either a specific file name or a pattern.
 if [[ $CONFIG_FILE ]]; then
     config_file=$(find /config -name "$CONFIG_FILE" 2> /dev/null | sort | shuf -n 1)
@@ -38,8 +43,13 @@ if is_enabled "$KILL_SWITCH"; then
 fi
 
 # Docker secret that contains the credentials for accessing the VPN.
+if [[ $AUTH_SECRET ]] && [ ! -f "$AUTH_SECRET" ]; then
+    echo "AUTH_SECRET file not found" >&2
+    exit 1
+fi
+
 if [[ $AUTH_SECRET ]]; then
-    openvpn_args+=("--auth-user-pass" "/run/secrets/$AUTH_SECRET")
+    openvpn_args+=("--auth-user-pass" "$AUTH_SECRET")
 fi
 
 openvpn "${openvpn_args[@]}" &

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,8 @@ services:
     devices:
       - /dev/net/tun:/dev/net/tun
     environment:
-      - ALLOWED_SUBNETS=192.168.10.0/24
+      ALLOWED_SUBNETS: 192.168.10.0/24
+      AUTH_SECRET: /config/credentions.txt
     volumes:
       - ./local:/config
     restart: unless-stopped


### PR DESCRIPTION
File entry.sh contains a number of undeclared variables. When accessing them, if they do not have a specific value, we received an error stating that a non-existent variable is being accessed.

This behavior is defined in the file header.

In order to correct this behavior, additional initialization of all variables was performed. If they are passed to the script, this value will be used. If not, the default values will be used. That is, empty values for all but `KILL_SWITCH`.

We also updated the alpine image to the latest stable version. And fixed the example of a docker-compose file referenced from the README.

Also, the `AUTH_SECRET` variable now contains the full path to the user data file. This will allow you to control the file location more precisely. And added a check, if the path to the file is set, we check that it is there before starting the openvpn process.